### PR TITLE
Fixed default sort value to descending in user manager for version 0.2.2 of Freequiz

### DIFF
--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -25,8 +25,8 @@
                                 ["Last login", "last_sign_in_at"]
                             ] %>
                             <% order_criteria = [
-                                ["Ascending", "ASC"],
-                                ["Descending", "DESC"]
+                                ["Descending", "DESC"],
+                                ["Ascending", "ASC"]
                             ] %>
                             <%= form.label :sort, "Sort by", class: "input-group-text" %>
                             <%= form.select :order, options_for_select(order_criteria, selected: params[:order]), {}, { class: "form-select" } %>


### PR DESCRIPTION
Default value should be descending because that's what order defaults to